### PR TITLE
fix: use opensearch for zeebe instead of elasticsearch

### DIFF
--- a/charts/zeebe-cluster-helm/Chart.lock
+++ b/charts/zeebe-cluster-helm/Chart.lock
@@ -2,11 +2,14 @@ dependencies:
 - name: elasticsearch
   repository: https://helm.elastic.co
   version: 7.10.2
+- name: opensearch
+  repository: https://opensearch-project.github.io/helm-charts/
+  version: 1.8.0
 - name: kibana
   repository: https://helm.elastic.co
   version: 7.9.3
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
   version: 12.0.4
-digest: sha256:a31c117476c52d7f2aaac521af1d5aebb4c0c7c2a3c59eaad16dfee7035a9cd5
-generated: "2021-12-23T13:19:59.735061+02:00"
+digest: sha256:d0a8f85c97a601c7af44209aa3c461800a64e357db8d6518fe37e96fad72bfd5
+generated: "2022-03-02T10:10:27.942604+02:00"

--- a/charts/zeebe-cluster-helm/Chart.yaml
+++ b/charts/zeebe-cluster-helm/Chart.yaml
@@ -3,13 +3,17 @@ appVersion: "1.2.8"
 description: Zeebe Cluster Helm Chart for Kubernetes
 name: zeebe-cluster-helm
 type: application
-version: 1.2.13
+version: 1.2.14
 icon: https://helm.camunda.io/imgs/zeebe-logo.png
 dependencies:
 - name: elasticsearch
   repository: "https://helm.elastic.co"
   version: 7.10.2
   condition: "elasticsearch.enabled"
+- name: opensearch
+  repository: https://opensearch-project.github.io/helm-charts/
+  version: 1.8.0
+  condition: "opensearch.enabled"
 - name: kibana
   repository: "https://helm.elastic.co" 
   version: 7.9.3

--- a/charts/zeebe-cluster-helm/values.yaml
+++ b/charts/zeebe-cluster-helm/values.yaml
@@ -8,7 +8,7 @@ annotations: {}
 global:
   elasticsearch:
     url:
-    host: "elasticsearch-master"
+    host: "opensearch-cluster-master"
     port: 9200
   zeebe: "{{ .Release.Name }}-zeebe"
 
@@ -44,12 +44,16 @@ gateway:
     annotations: {}
 
 elasticsearch:
+  enabled: false
+  imageTag: 7.16.2
+
+opensearch:
   enabled: true
   imageTag: 7.16.2
 
 kibana:
   enabled: false
-  imageTag: 7.16.2
+  imageTag: 1.2.4
 
 prometheus:
   enabled: false

--- a/charts/zeebe-cluster-helm/values.yaml
+++ b/charts/zeebe-cluster-helm/values.yaml
@@ -49,11 +49,11 @@ elasticsearch:
 
 opensearch:
   enabled: true
-  imageTag: 7.16.2
+  imageTag: 1.2.4
 
 kibana:
   enabled: false
-  imageTag: 1.2.4
+  imageTag: 7.16.2
 
 prometheus:
   enabled: false

--- a/charts/zeebe-operate-helm/values.yaml
+++ b/charts/zeebe-operate-helm/values.yaml
@@ -2,9 +2,9 @@ global:
   zeebe: "{{ .Release.Name }}-zeebe"
   zeebePort: 26500
   elasticsearch:
-    host: "elasticsearch-master"
+    host: "opensearch-cluster-master"
     port: 9200
-    clusterName: "elasticsearch"
+    clusterName: "opensearch"
     prefix: zeebe-record
     url:
 

--- a/charts/zeebe-tasklist-helm/values.yaml
+++ b/charts/zeebe-tasklist-helm/values.yaml
@@ -1,9 +1,9 @@
 global:
   zeebe: "{{ .Release.Name }}-zeebe"
   elasticsearch:
-    host: "elasticsearch-master"
+    host: "opensearch-cluster-master"
     port: 9200
-    clusterName: "elasticsearch"
+    clusterName: "opensearch"
 
 logging:
   level:


### PR DESCRIPTION
1) Not sure about open search deployment if it should come from here but have added the dependency. I guess we may have to remove it
2) Did not modify templates or elastic search template strings but just host points to open search.